### PR TITLE
Fix the GOTO iz_max case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nnls"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Nil Goyette <nil.goyette@imeka.ca>"]
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ I decided to port nnls to Rust because:
 
 - This is not idiomatic Rust. I tried cleaning and enhancing the code but it's not always possible.
 - I use [ndarray](https://github.com/rust-ndarray/ndarray). You might prefer something else. I do not plan to change this but you're welcome to discuss it.
-- There are currently 3 `panic!` in the code because there are 3 code paths in the original code which use `goto` that I couldn't translate properly to Rust. I planned to handle those cases but it turns out that they are never called. As I wrote, `nnls` has been extensively used and I couldn't find any dataset that triggers those conditions. If my programs ever panic because of this, it will be repaired quickly.
+- There are currently 1 `panic!` in the code because there are 1 code paths in the original code which use `goto` that I couldn't translate properly to Rust. I planned to handle that case but it turns out that it's never called. As I wrote, `nnls` has been extensively used and I couldn't find any dataset that triggers that condition. If my programs ever panic because of this, it will be repaired quickly.

--- a/tests/nnls.rs
+++ b/tests/nnls.rs
@@ -22,6 +22,20 @@ fn test_nnls_2() {
 }
 
 #[test]
+fn test_trap() {
+    let a = arr2(&[
+        [9.6110e-8, 7.9576e-17, 2.7234e-44, 3.4490e-44],
+        [7.9576e-17, 2.0449e-7, 7.4360e-44, 9.4173e-44],
+        [2.7234e-44, 7.4360e-44, 3.1651e-7, 2.9014e-44],
+        [3.4490e-44, 9.4173e-44, 2.9014e-44, 4.3443e-7],
+    ]);
+    let b = arr1(&[-2.4678e-17, -6.7118e-17, 3.6306e-44, 4.5923e-44]);
+    let (x, r_norm) = nnls(a.view(), b.view());
+    assert_relative_eq!(x, arr1(&[0.0, 0.0, 0.0, 0.0]), epsilon = 1e-5);
+    assert_relative_eq!(r_norm, 0.0, epsilon = 1e-5);
+}
+
+#[test]
 fn test_mixture_of_exponentials() {
     let mut t0 = Array1::zeros(19);
     t0[0] = 2.0;


### PR DESCRIPTION
Hi @jordanmb. This PR should fix your problem. However I had only a single example which

- triggers a warning in Fortran `Real constant underflows its kind at` so I changed your numbers a little
- contains number almost equal to 0.0
- gives an answer of [0.0, 0.0, 0.0, 0.0]. It's the same answer as the official Fortran implementation but I would have preferred an example that gives a non-zero answer.

It would be nice if you can provide another example that lead to a non-zero answer. I understand that it might be hard to do because you don't know the answer beforehand :) So maybe just another example that is not a 4x4 matrix?

Fix #1 